### PR TITLE
Update Builder.php

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -871,7 +871,7 @@ class Builder extends BaseBuilder
             }
         }
 
-        return call_user_func_array('parent::where', $params);
+        return parent::where(...$params);
     }
 
     /**


### PR DESCRIPTION
Gets rid of the constant `Use of "parent" in callables is deprecated in /var/www/melissa/vendor/jenssegers/mongodb/src/Query/Builder.php on line 874` warnings.