### PR TITLE
Fix PHP 8.3 deprecation in Query\Builder::where()

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -871,7 +871,7 @@ class Builder extends BaseBuilder
             }
         }
 
-        return call_user_func_array('parent::where', $params);
+        return parent::where(...$params);
     }
 
     /**


### PR DESCRIPTION
## Problem

On PHP 8.3, every `where()` call emits:

```
Deprecated: Use of "parent" in callables is deprecated in src/Query/Builder.php on line 874
```

`'parent::where'` is a string callable, which PHP 8.3 [deprecates](https://wiki.php.net/rfc/deprecate_partially_supported_callables). Since `where()` runs on nearly every query, it floods logs and error trackers.

## Fix

```diff
-        return call_user_func_array('parent::where', $params);
+        return parent::where(...$params);
```

Behavior-preserving: `$params` (from `func_get_args()`) is still passed positionally, including the by-reference operator mutation above it. Only the deprecated callable form is removed.